### PR TITLE
CTECH-3342: add test for proper handling of optional parameters with default values

### DIFF
--- a/src/Lusid.Sdk.Examples/Tutorials/MarketData/Instruments.cs
+++ b/src/Lusid.Sdk.Examples/Tutorials/MarketData/Instruments.cs
@@ -8,8 +8,6 @@ using Lusid.Sdk.Examples.Utilities;
 using Lusid.Sdk.Utilities;
 using LusidFeatures;
 using NUnit.Framework;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Lusid.Sdk.Examples.Tutorials.MarketData
 {


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue

There is a bug in the SDK where optional parameters of an object, when not specified in the call to the constructor, are assigned values other than the stated default value of that parameter in LUSID. This PR adds a test that demonstrates intended behavior and should pass when the bug is fixed.